### PR TITLE
Use common awslogs role for cloudwatch log pushing, conditionally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ target/
 .ipynb_checkpoints
 
 .idea
-
+*.iml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,4 @@ COMPONENT_NAME: vagrant
 COMPONENT_SHA: vagrant
 COMPONENT_VERSION: vagrant
 php_fpm_socket_path: '/var/run/php/php5.6-fpm.sock'
-enable_logging: false
+enable_logging: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ COMPONENT_NAME: vagrant
 COMPONENT_SHA: vagrant
 COMPONENT_VERSION: vagrant
 php_fpm_socket_path: '/var/run/php/php5.6-fpm.sock'
+enable_logging: false

--- a/files/apache-awslogs-agent.conf.j2
+++ b/files/apache-awslogs-agent.conf.j2
@@ -1,0 +1,6 @@
+[/var/log/apache2/error.log]
+file = /var/log/apache2/error.log
+log_group_name = {{ env }}-{{ brand }}-/var/log/apache2/error.log
+log_stream_name = {instance_id}
+datetime_format = [%a %b %d %H:%M:%S.%f %Y]
+batch_size = 10

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,4 +24,8 @@ galaxy_info:
     - cloud
     - clustering
     - networking
-dependencies: []
+dependencies:
+  - name: awslogs
+    src: git+git@github.com:webhop/ansible-awslogs.git
+    version: master
+    when: enable_logging

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -1,0 +1,32 @@
+# agent_config_dir variable comes form awslogs role
+- name: "Install the apache config template into {{ agent_config_dir }}"
+  copy:
+    src: apache-awslogs-agent.conf.j2
+    dest: "{{ agent_config_dir }}/apache.conf.j2"
+
+- name: Add log_group configuration block for apache
+  blockinfile:
+    dest: "{{ scripts_dir }}/logs_group_configuration.py"
+    create: no
+    insertafter: "COMPONENT_SPECIFIC_CONF_BLOCKS_FOLLOW"
+    marker: "# {mark} APACHE LOG CONFIG"
+    block: |
+      '%(env)s-%(brand)s-/var/log/apache2/error.log': {
+          'retention_days': 14,
+          'metric_filters':
+          [
+              {
+                  'name': '%(env)s-%(brand)s-apache-log-errors',
+                  'filter_pattern': 'Error',
+                  'metric_transformations':
+                  [
+                      {
+                          'metricName': 'ApacheErrors',
+                          'metricNamespace': 'WEBHOP',
+                          'metricValue': '1',
+                          'defaultValue': 0
+                      }
+                  ]
+              }
+          ]
+      },

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -1,4 +1,4 @@
-# scripts_dir and awslogs_agent_config_dir variables come from the awslogs role
+# awslogs_scripts_dir and awslogs_agent_config_dir variables come from the awslogs role
 - name: "Install the apache config template into {{ awslogs_agent_config_dir }}"
   copy:
     src: apache-awslogs-agent.conf.j2
@@ -6,7 +6,7 @@
 
 - name: Add log_group configuration block for apache
   blockinfile:
-    dest: "{{ scripts_dir }}/logs_group_configuration.py"
+    dest: "{{ awslogs_scripts_dir }}/logs_group_configuration.py"
     create: no
     insertafter: "COMPONENT_SPECIFIC_CONF_BLOCKS_FOLLOW"
     marker: "# {mark} APACHE LOG CONFIG"

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -12,7 +12,7 @@
     marker: "# {mark} APACHE LOG CONFIG"
     block: |
       '%(env)s-%(brand)s-/var/log/apache2/error.log': {
-          'retention_days': 14,
+          'retention_days': 7,
           'metric_filters':
           [
               {
@@ -29,4 +29,7 @@
                   ]
               }
           ]
+      },
+      '%(env)s-%(brand)s-/var/log/apache2/access.log': {
+          'retention_days': 1
       },

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -1,4 +1,4 @@
-# awslogs_agent_config_dir variable comes form awslogs role
+# scripts_dir and awslogs_agent_config_dir variables come from the awslogs role
 - name: "Install the apache config template into {{ awslogs_agent_config_dir }}"
   copy:
     src: apache-awslogs-agent.conf.j2

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -1,8 +1,8 @@
-# agent_config_dir variable comes form awslogs role
-- name: "Install the apache config template into {{ agent_config_dir }}"
+# awslogs_agent_config_dir variable comes form awslogs role
+- name: "Install the apache config template into {{ awslogs_agent_config_dir }}"
   copy:
     src: apache-awslogs-agent.conf.j2
-    dest: "{{ agent_config_dir }}/apache.conf.j2"
+    dest: "{{ awslogs_agent_config_dir }}/apache.conf.j2"
 
 - name: Add log_group configuration block for apache
   blockinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,3 +112,6 @@
 - name: Apply all Ubuntu security updates
   command: /usr/bin/unattended-upgrade
   when: not skip_security_updates|default(False)
+
+- include: logging.yml
+  when: enable_logging


### PR DESCRIPTION
Depend on it conditionally.
Setup apache-specific logging configuration conditionally.
Dependents have to opt in. No change of behaviour if they don't change.