### PR TITLE
Disable access to /html

### DIFF
--- a/templates/webhop-default.conf.j2
+++ b/templates/webhop-default.conf.j2
@@ -28,6 +28,11 @@ ExtendedStatus On
   <Directory {{ docroot }}>
     AllowOverride All
   </Directory>
+  
+  <Directory {{ docroot }}/html>
+    Order allow,deny
+    Deny from all
+  </Directory>
 
   <IfModule mod_fastcgi.c>
     AddType application/x-httpd-fastphp5 .php


### PR DESCRIPTION
Currently we leak server details via the default apache index file. This will block that.