### PR TITLE
Allows usage of other versions of PHP (i.e. PHP-FPM v7).

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This role assumes the default site being provisioned is a PHP-based site using t
 
 ##### Defaults
 
+- `php_fpm_major_version` - Which PHP FPM version to use (**php5**)
 - `apache_force_ssl` - Forces apache to respond with https using `SetEnv https on` (**True**)
 - `docroot` - Filesystem path for web assets (**/var/www**)
 - `enable_pagespeed` - Enables google pagespeed integration (**false**)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 apache_force_ssl: true
 enable_pagespeed: False
 enable_mod_status: true
+php_fpm_major_version: "php5"
 enable_php_fpm_status: true
 mod_status_endpoint: "/server-status"
 COMPONENT_NAME: vagrant

--- a/templates/webhop-default.conf.j2
+++ b/templates/webhop-default.conf.j2
@@ -35,10 +35,10 @@ ExtendedStatus On
   </Directory>
 
   <IfModule mod_fastcgi.c>
-    AddType application/x-httpd-fastphp5 .php
-    Action application/x-httpd-fastphp5 /php5-fcgi
-    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -socket {{ php_fpm_socket_path }} -pass-header Authorization -idle-timeout 120
+    AddType application/x-httpd-fast{{ php_fpm_major_version }} .php
+    Action application/x-httpd-fast{{ php_fpm_major_version }} /{{ php_fpm_major_version }}-fcgi
+    Alias /{{ php_fpm_major_version }}-fcgi /usr/lib/cgi-bin/{{ php_fpm_major_version }}-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/{{ php_fpm_major_version }}-fcgi -socket {{ php_fpm_socket_path }} -pass-header Authorization -idle-timeout 120
 
     <Directory /usr/lib/cgi-bin>
       Require all granted
@@ -57,8 +57,8 @@ ExtendedStatus On
 
   {% if enable_php_fpm_status %}
   <LocationMatch '/fpm-status'>
-    SetHandler php5-fcgi-virt
-    Action php5-fcgi-virt /php5-fcgi virtual
+    SetHandler {{ php_fpm_major_version }}-fcgi-virt
+    Action {{ php_fpm_major_version }}-fcgi-virt /{{ php_fpm_major_version }}-fcgi virtual
   </LocationMatch>
   {% endif %}
 
@@ -98,10 +98,10 @@ ExtendedStatus On
   </Directory>
 
   <IfModule mod_fastcgi.c>
-    AddType application/x-httpd-fastphp5 .php
-    Action application/x-httpd-fastphp5 /php5-fcgi-ssl
-    Alias /php5-fcgi-ssl /usr/lib/cgi-bin/php5-fcgi-ssl
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi-ssl -socket {{ php_fpm_socket_path }} -pass-header Authorization -idle-timeout 120
+    AddType application/x-httpd-fast{{ php_fpm_major_version }} .php
+    Action application/x-httpd-fast{{ php_fpm_major_version }} /{{ php_fpm_major_version }}-fcgi-ssl
+    Alias /{{ php_fpm_major_version }}-fcgi-ssl /usr/lib/cgi-bin/{{ php_fpm_major_version }}-fcgi-ssl
+    FastCgiExternalServer /usr/lib/cgi-bin/{{ php_fpm_major_version }}-fcgi-ssl -socket {{ php_fpm_socket_path }} -pass-header Authorization -idle-timeout 120
 
     <Directory /usr/lib/cgi-bin>
       Require all granted


### PR DESCRIPTION
```Paul Maddern [13:22]
Not gonna paste it all …

- webhop.apache2 (allow-php7) was installed successfully

TASK [webhop.apache2 : Symlink sites-available/webhop-default.conf to sites-enabled/webhop-default.conf] ***
ok: [www-truthabouthaircolor-com]

And the file…

<IfModule mod_fastcgi.c>
    AddType application/x-httpd-fastphp7 .php
    Action application/x-httpd-fastphp7 /php7-fcgi
    Alias /php7-fcgi /usr/lib/cgi-bin/php7-fcgi
    FastCgiExternalServer /usr/lib/cgi-bin/php7-fcgi -socket /var/run/php/php7.1-fpm.sock -pass-header Authorization -idle-timeout 120

    <Directory /usr/lib/cgi-bin>
      Require all granted
    </Directory>
  </IfModule>
...
  <IfModule mod_fastcgi.c>
    AddType application/x-httpd-fastphp7 .php
    Action application/x-httpd-fastphp7 /php7-fcgi-ssl
    Alias /php7-fcgi-ssl /usr/lib/cgi-bin/php7-fcgi-ssl
    FastCgiExternalServer /usr/lib/cgi-bin/php7-fcgi-ssl -socket /var/run/php/php7.1-fpm.sock -pass-header Authorization -idle-timeout 120

    <Directory /usr/lib/cgi-bin>
      Require all granted
    </Directory>
  </IfModule>
```

![screen shot 2018-03-28 at 13 26 29](https://user-images.githubusercontent.com/1250035/38028723-a98dfb0c-328b-11e8-9e25-8e6b624b324a.png)
