### PR TITLE
PLAT-247: Only enable SSL if there are available certs.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,10 @@
     - rewrite
     - headers
     - expires
-    - ssl
+
+- name: Enable SSL if there are certs available
+  apache2_module: name=ssl state=present
+  when: stat_ssl_cert.stat.exists
 
 - name: Enable mod_status apache module
   apache2_module: name=status state=present

--- a/templates/webhop-default.conf.j2
+++ b/templates/webhop-default.conf.j2
@@ -6,7 +6,7 @@ ExtendedStatus On
   ServerAdmin webmaster@localhost
   DocumentRoot {{ docroot }}
 
-  {% if apache_force_ssl %}
+  {% if apache_force_ssl and stat_ssl_cert.stat.exists %}
   SetEnv HTTPS on
   {% endif %}
   ExpiresActive On


### PR DESCRIPTION
https://beamly.atlassian.net/browse/PLAT-247

Prevents SSL apache2 module from being enabled hence the if clause `<IfModule ssl_module>` in the ports.conf file means the listen 443 is never actioned;

```
vagrant@www-adidasbodycare-com:/var/www$ sudo lsof -i
COMMAND     PID     USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
rpcbind     549     root    6u  IPv4   7791      0t0  UDP *:sunrpc 
rpcbind     549     root    7u  IPv4   7794      0t0  UDP *:716 
rpcbind     549     root    8u  IPv4   7795      0t0  TCP *:sunrpc (LISTEN)
rpcbind     549     root    9u  IPv6   7796      0t0  UDP *:sunrpc 
rpcbind     549     root   10u  IPv6   7797      0t0  UDP *:716 
rpcbind     549     root   11u  IPv6   7798      0t0  TCP *:sunrpc (LISTEN)
dhclient    573     root    5u  IPv4   7695      0t0  UDP *:bootpc 
dhclient    573     root   20u  IPv4   7654      0t0  UDP *:2832 
dhclient    573     root   21u  IPv6   7655      0t0  UDP *:34276 
rpc.statd   583    statd    4u  IPv4   7855      0t0  UDP localhost:759 
rpc.statd   583    statd    7u  IPv4   7864      0t0  UDP *:50545 
rpc.statd   583    statd    8u  IPv4   7867      0t0  TCP *:46426 (LISTEN)
rpc.statd   583    statd    9u  IPv6   7870      0t0  UDP *:53429 
rpc.statd   583    statd   10u  IPv6   7873      0t0  TCP *:37703 (LISTEN)
dhclient   1415     root    8u  IPv4  10063      0t0  UDP *:bootpc 
dhclient   1415     root   20u  IPv4  10028      0t0  UDP *:28619 
dhclient   1415     root   21u  IPv6  10029      0t0  UDP *:16385 
sshd       1584     root    3u  IPv4  10710      0t0  TCP *:ssh (LISTEN)
sshd       1584     root    4u  IPv6  10712      0t0  TCP *:ssh (LISTEN)
sshd       8965     root    3u  IPv4  54642      0t0  TCP www-adidasbodycare-com:ssh->10.0.2.2:49821 (ESTABLISHED)
sshd       9033  vagrant    3u  IPv4  54642      0t0  TCP www-adidasbodycare-com:ssh->10.0.2.2:49821 (ESTABLISHED)
apache2    9734     root    4u  IPv6  55753      0t0  TCP *:http (LISTEN)
apache2    9737 www-data    4u  IPv6  55753      0t0  TCP *:http (LISTEN)
apache2    9738 www-data    4u  IPv6  55753      0t0  TCP *:http (LISTEN)
apache2    9739 www-data    4u  IPv6  55753      0t0  TCP *:http (LISTEN)
sendmail- 12297     root    4u  IPv4  26108      0t0  TCP localhost:smtp (LISTEN)
sendmail- 12297     root    5u  IPv4  26109      0t0  TCP localhost:submission (LISTEN)
```

And when the site.yml includes it;
```
vagrant@www-adidasbodycare-com:~$ sudo lsof -i
COMMAND     PID     USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
dhclient    504     root    5u  IPv4   7254      0t0  UDP *:bootpc 
dhclient    504     root   20u  IPv4   7209      0t0  UDP *:15010 
dhclient    504     root   21u  IPv6   7210      0t0  UDP *:48198 
rpcbind     604     root    6u  IPv4   8069      0t0  UDP *:sunrpc 
rpcbind     604     root    7u  IPv4   8072      0t0  UDP *:774 
rpcbind     604     root    8u  IPv4   8073      0t0  TCP *:sunrpc (LISTEN)
rpcbind     604     root    9u  IPv6   8074      0t0  UDP *:sunrpc 
rpcbind     604     root   10u  IPv6   8075      0t0  UDP *:774 
rpcbind     604     root   11u  IPv6   8076      0t0  TCP *:sunrpc (LISTEN)
rpc.statd   718    statd    4u  IPv4   8231      0t0  UDP localhost:894 
rpc.statd   718    statd    7u  IPv4   8236      0t0  UDP *:34284 
rpc.statd   718    statd    8u  IPv4   8239      0t0  TCP *:57326 (LISTEN)
rpc.statd   718    statd    9u  IPv6   8242      0t0  UDP *:57468 
rpc.statd   718    statd   10u  IPv6   8245      0t0  TCP *:36115 (LISTEN)
sendmail-  1144     root    4u  IPv4   9319      0t0  TCP localhost:smtp (LISTEN)
sendmail-  1144     root    5u  IPv4   9320      0t0  TCP localhost:submission (LISTEN)
sshd       1520     root    3u  IPv4  10390      0t0  TCP *:ssh (LISTEN)
sshd       1520     root    4u  IPv6  10392      0t0  TCP *:ssh (LISTEN)
memcached  5991 memcache   26u  IPv4  21940      0t0  TCP localhost:11211 (LISTEN)
mysqld     9743    mysql   10u  IPv4  26454      0t0  TCP *:mysql (LISTEN)
sshd      10946     root    3u  IPv4  28700      0t0  TCP www-adidasbodycare-com:ssh->10.0.2.2:50328 (ESTABLISHED)
sshd      11013  vagrant    3u  IPv4  28700      0t0  TCP www-adidasbodycare-com:ssh->10.0.2.2:50328 (ESTABLISHED)
apache2   11057     root    4u  IPv6  29538      0t0  TCP *:http (LISTEN)
apache2   11057     root    6u  IPv6  29542      0t0  TCP *:https (LISTEN)
apache2   11059 www-data    4u  IPv6  29538      0t0  TCP *:http (LISTEN)
apache2   11059 www-data    6u  IPv6  29542      0t0  TCP *:https (LISTEN)
apache2   11060 www-data    4u  IPv6  29538      0t0  TCP *:http (LISTEN)
apache2   11060 www-data    6u  IPv6  29542      0t0  TCP *:https (LISTEN)
apache2   11061 www-data    4u  IPv6  29538      0t0  TCP *:http (LISTEN)
apache2   11061 www-data    6u  IPv6  29542      0t0  TCP *:https (LISTEN)
```