### PR TITLE
Use a shared EFS mount for the cached pagespeed images.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,8 @@ log_config:
   apache_access:
     log_file: "/var/log/apache2/access.log"
     retention: 1
+
+# sleep time in seconds between retries
+retry_wait: 10
+# max time retrying in seconds
+retry_up_to: 600

--- a/files/pagespeed.conf
+++ b/files/pagespeed.conf
@@ -23,7 +23,7 @@
 
     # The ModPagespeedFileCachePath directory must exist and be writable
     # by the apache user (as specified by the User directive).
-    ModPagespeedFileCachePath            "/tmp"
+    ModPagespeedFileCachePath            "/tmp/pagespeed"
 
     # LogDir is needed to store various logs, including the statistics log
     # required for the console.

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,0 +1,2 @@
+jinja2
+boto3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,10 +114,6 @@
     src: pagespeed.conf
     dest: /etc/apache2/mods-available/pagespeed.conf
 
-- name: Enable the pagespeed module
-  apache2_module: state=present name=pagespeed
-  when: enable_pagespeed
-
 - name: Disable the pagespeed module
   apache2_module: state=absent name=pagespeed
   when: not enable_pagespeed
@@ -150,3 +146,6 @@
 
 - include: logging.yml
   when: enable_logging
+
+- include: pagespeed.yml
+  when: enable_pagespeed

--- a/tasks/pagespeed.yml
+++ b/tasks/pagespeed.yml
@@ -1,0 +1,25 @@
+---
+- include: virtualenv.yml
+
+- name: Enable the pagespeed module
+  apache2_module: state=present name=pagespeed
+
+- name: Print shared_filesystem_type
+  debug:
+    var: shared_filesystem_type
+
+- name: Install Upstart script
+  template:
+    src: upstart/create_pagespeed_cache_folder.conf.j2
+    dest: /etc/init/apache-pagespeed-cache.conf
+    mode: 0644
+    owner: root
+    group: root
+
+- name: Copy the pagespeed-upstart.sh bash script
+  template:
+    src: "pagespeed-upstart.sh.j2"
+    dest: "{{ scripts_dir }}/apache-pagespeed/pagespeed-upstart.sh.j2"
+    owner: "{{ scripts_owner }}"
+    group: "{{ scripts_group }}"
+    mode: 0755

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -1,0 +1,36 @@
+---
+- name: Install virtualenv package
+  pip:
+      name: virtualenv
+      state: latest
+
+- name: Create scripts directory if it doesn't exist
+  file:
+    path: "{{ scripts_dir }}/apache-pagespeed"
+    state: directory
+    owner: "{{ scripts_owner }}"
+    group: "{{ scripts_group }}"
+    mode: 0755
+
+- name: Create virtualenv directory if it doesn't exist
+  file:
+    path: "{{ virtualenv_dir }}"
+    state: directory
+    owner: "{{ scripts_owner }}"
+    group: "{{ scripts_group }}"
+    mode: 0755
+
+- name: Copy the requirements file
+  copy:
+    src: requirements.txt
+    dest: "{{ scripts_dir }}/apache-pagespeed/requirements.txt"
+    owner: "{{ scripts_owner }}"
+    group: "{{ scripts_group }}"
+    mode: 0755
+  when: create_virtualenv
+
+- name: Create virtualenv if create_virtualenv
+  pip:
+    requirements: "{{ scripts_dir }}/apache-pagespeed/requirements.txt"
+    virtualenv: "{{ virtualenv_dir }}/apache-pagespeed"
+  when: create_virtualenv

--- a/templates/pagespeed-upstart.sh.j2
+++ b/templates/pagespeed-upstart.sh.j2
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+{% if shared_filesystem_type|default('') == "none" %}
+    MOUNT_POINT="{{ none_shared_mount_point }}"
+    FS_TYPE="none"
+{% else %}
+    # Poll mountpoints retrying for {{ retry_up_to }} seconds
+    END=$((SECONDS+{{ retry_up_to }}))
+
+    echo "Detecting FS mountpoint (may take a while)..."
+
+    while [ "${MOUNT_POINT}" == "" ] && [ "${SECONDS}" -lt "${END}" ];
+    do
+        if /bin/mountpoint -q {{ gluster_shared_mount_point }}; then
+            MOUNT_POINT="{{ gluster_shared_mount_point }}"
+            FS_TYPE=gluster
+        elif /bin/mountpoint -q {{ efs_shared_mount_point }}; then
+            MOUNT_POINT="{{ efs_shared_mount_point }}"
+            FS_TYPE=efs
+        else
+            sleep {{ retry_wait }}
+        fi
+    done
+
+    if [ "${MOUNT_POINT}" == "" ]; then
+        echo "No valid mountpoints found, bye bye."
+        exit -1
+    fi
+
+    echo "Detected valid mountpoint at ${MOUNT_POINT}."
+{% endif %}
+
+    echo "Ensuring all files directories exist with the proper perms in ${MOUNT_POINT}..."
+    for dir in pagespeed
+    do
+        mkdir -p "${MOUNT_POINT}/${dir}"
+    done
+
+{% if shared_filesystem_type|default('') == "none" %}
+    echo "Chowning /mnt/none_shared to www-data..."
+    chown -R {{ shared_filesystem_owner }}:{{ shared_filesystem_owner }} "${MOUNT_POINT}"
+    echo "Done."
+{% endif %}
+
+    sudo ln -sfn "${MOUNT_POINT}/pagespeed" /tmp/pagespeed
+    echo "Created symlink for Pagespeed cache directory."

--- a/templates/upstart/create_pagespeed_cache_folder.conf.j2
+++ b/templates/upstart/create_pagespeed_cache_folder.conf.j2
@@ -1,0 +1,11 @@
+description "Upstart task for create_pagespeed_cache_folder"
+author "Beamly Platform Team <platform@beamly.com>"
+
+start on filesystem
+
+task
+console log
+
+script
+        exec bash -c {{ scripts_dir }}/apache-pagespeed/pagespeed-upstart.sh.j2
+end script

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,14 @@
+---
+# vars file for ansible-apache2-pagespeed
+scripts_dir: '/opt/beamly/scripts'
+virtualenv_dir: '/opt/beamly/virtualenvs'
+scripts_owner: root
+scripts_group: root
+
 docroot: /var/www
 php_fpm_socket_path: '/var/run/php/php5.6-fpm.sock'
+
+shared_filesystem_owner: www-data
+efs_shared_mount_point: /mnt/efs_shared
+gluster_shared_mount_point: /mnt/gluster_shared
+none_shared_mount_point: /mnt/none_shared


### PR DESCRIPTION
Noticing that some assets disappear/ reappear between page loads.  The assumption is that due to load balancing, the cache isn't always accessible between the instances.  This PR moves the cache to be contained in an EFS shared mount.

https://www.modpagespeed.com/doc/config_filters#multi_server
https://www.modpagespeed.com/doc/system#shm_cache

Note although this suggest using memcache across both the servers, this role isn't Drupal specific so usage of memcache is not guaranteed (a shared mount point is far more likely).