### PR TITLE
Bodge intended to provide a fix for the problem where the pagespeed m…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,30 @@
 ---
+# Pagespeed module is failing on apt-cache update just after upgrading to Ubuntu 18.04
+# bodging in a fix from https://support.plesk.com/hc/en-us/articles/360021566754--apt-update-is-not-working-on-Plesk-server-with-Ubuntu-or-Debian-after-installing-PageSpeed-Apache-module-through-Google-PageSpeed-Insights-extension-The-repository-http-dl-google-com-linux-mod-pagespeed-deb-stable-Release-is-not-signed
+
+- name: Check pagespeed repo file exists
+  stat: path=/etc/apt/sources.list.d/mod-pagespeed.list
+  register: ps_apt_stat
+  failed_when: not ps_apt_stat.stat.exists
+
+- name: Moving out pagespeed repo
+  command: mv /etc/apt/sources.list.d/mod-pagespeed.list /tmp/
+  when: ps_apt_stat.stat.exists
+
+- name: Update the apt-cache to remove pagespeed apt from cache
+  apt: update_cache=yes cache_valid_time=3600
+
+- name: Install the latest version of the signing key
+  apt_key: 
+    url: https://dl-ssl.google.com/linux/linux_signing_key.pub 
+    state: present
+
+- name: Moving pagespeed repo back in ready for the update
+  stat: path=/tmp/mod-pagespeed.list
+  command: mv /tmp/mod-pagespeed.list /etc/apt/sources.list.d/
+
+# End of bodge
+
 - name: Add Apache2 PPA
   apt_repository:
     repo: 'ppa:ondrej/apache2'


### PR DESCRIPTION
…odule's APT repo at Google does not have a signing key expiration problem, just after upgrading OS to 18.04