### PR TITLE
SOP-672: libapache2-mod-fastcgi has been deprecated, try out using libapache2-mod-fcgid instead.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,6 @@
     repo: "deb http://eu-central-1.ec2.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} multiverse"
     update_cache: yes
 
-
 - name: Install latest version of Apache
   apt:
     name: apache2
@@ -58,6 +57,18 @@
     name: libapache2-mod-fastcgi
     state: latest
   when: ansible_lsb.major_release|int <= 16
+
+- name: Enable Apache2 modules
+  command: "a2enmod {{ item }}"
+  with_items:
+    - proxy_fcgi
+  when: ansible_lsb.major_release|int > 16
+
+- name: Enable Apache2 PHP-FPM conf
+  command: "a2enconf {{ item }}"
+  with_items:
+    - "php{{ php_version }}-fpm"
+  when: ansible_lsb.major_release|int > 16
 
 - name: Disable Apache2 prefork MPM modules
   command: "a2dismod {{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,19 +47,10 @@
     owner: www-data
     group: www-data
 
-# Found this here: https://www.digitalocean.com/community/tutorials/how-to-configure-nginx-as-a-web-server-and-reverse-proxy-for-apache-on-one-ubuntu-18-04-server
-# Which points to here: https://mirrors.edge.kernel.org/ubuntu/pool/multiverse/liba/libapache-mod-fastcgi/libapache2-mod-fastcgi_2.4.7~0910052141-1.2_amd64.deb
-# Which I've uploaded to S3 to prevent panic when mirrors.edge.kernel.org inevitably goes offline.
-
-- name: Download libapache2-mod-fastcgi for Ubuntu 18.04
-  get_url:
-    url: https://s3.amazonaws.com/assets.beamly.com/packages/libapache2-mod-fastcgi_2.4.7_0910052141-1.2_amd64.deb
-    dest: /tmp/libapache2-mod-fastcgi_2.4.7_0910052141-1.2_amd64.deb
-  when: ansible_lsb.major_release|int > 16
-
-- name: Install libapache2-mod-fastcgi for Ubuntu 18.04
+- name: Install libapache2-mod-fcgid for Ubuntu 18.04
   apt:
-    deb: /tmp/libapache2-mod-fastcgi_2.4.7_0910052141-1.2_amd64.deb
+    name: libapache2-mod-fcgid
+    state: latest
   when: ansible_lsb.major_release|int > 16
 
 - name: Install libapache2-mod-fastcgi for Ubuntu < 18.04


### PR DESCRIPTION
https://beamly.atlassian.net/browse/SOP-672

![Screenshot 2019-06-11 at 12 20 04](https://user-images.githubusercontent.com/1250035/59267883-43d15300-8c43-11e9-8390-577aed6e65d0.png)
