### PR TITLE
SOP-889: Investigate fixing 408 log entries generated by ELB healthchecks in apache

### DIFF
--- a/templates/webhop-default.conf.j2
+++ b/templates/webhop-default.conf.j2
@@ -34,6 +34,10 @@ ExtendedStatus On
     Deny from all
   </Directory>
 
+  <IfModule mod_reqtimeout.c>
+    RequestReadTimeout header=65 body=65
+  </IfModule>
+
   <IfModule mod_fastcgi.c>
     AddType application/x-httpd-fast{{ php_fpm_major_version }} .php
     Action application/x-httpd-fast{{ php_fpm_major_version }} /{{ php_fpm_major_version }}-fcgi


### PR DESCRIPTION
https://beamly.atlassian.net/browse/SOP-889

Addresses Slowloris attack vector, and should assist with ridding us of our 408 HEAD responses.

**NOTE**: ~Values do need tweaking, I've just run out of time today~ Set this to 65, as the ELB healthchecks are 60s.