### PR TITLE
SOP-936: A dependency is installing php 7.3 instead of 7.2...

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,11 @@
 - name: Disable Apache2 prefork MPM modules
   command: "a2dismod {{ item }}"
   with_items:
-    - "php{{ php_version }}"
+    - php5.6
+    - php7.0
+    - php7.1
+    - php7.2
+    - php7.3
     - mpm_prefork
   register: apache2_module_output
   changed_when: apache2_module_output.stdout.find(item + ' already') == -1


### PR DESCRIPTION
https://beamly.atlassian.net/browse/SOP-936
https://beamly.atlassian.net/browse/CR-634

Both this and https://github.com/webhop/ansible-php7/pull/8 are necessary as without this, then prefork can't be disabled as we previously targeted just the active version of PHP.

**NOTE** the `ignore_errors: true` ~ this is safe to merge.