### PR TITLE
SOP-1080: Adds php7.4 now it's properly been released, so it can also have it's prefork MPM module disabled on build.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,6 +76,7 @@
     - php7.1
     - php7.2
     - php7.3
+    - php7.4
     - mpm_prefork
   register: apache2_module_output
   changed_when: apache2_module_output.stdout.find(item + ' already') == -1


### PR DESCRIPTION
https://beamly.atlassian.net/browse/SOP-1080

http://goserver.go.beamly.com:8153/go/tab/build/detail/cc2rimmellondondrupal-1.x-bake/290/build/1/bake_ami

```
4"%!(PACKER_COMMA) "end": "2019-12-19 11:22:28.142346"%!(PACKER_COMMA) "failed": true%!(PACKER_COMMA) "item": "mpm_prefork"%!(PACKER_COMMA) "rc": 1%!(PACKER_COMMA) "start": "2019-12-19 11:22:28.110592"%!(PACKER_COMMA) "stderr": "ERROR: The following modules depend on mpm_prefork and need to be disabled first: php7.4"%!(PACKER_COMMA) "stdout": ""%!(PACKER_COMMA) "stdout_lines": []%!(PACKER_COMMA) "warnings": []}
```