### PR TITLE
fix(systemd): Adds commands for systemd OS version differences.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 apache_force_ssl: true
 enable_pagespeed: False
 enable_mod_status: true
-php_fpm_major_version: "php5"
-php_version: 5.6
+php_fpm_major_version: "php7"
+php_version: 7.2
 enable_php_fpm_status: true
 mod_status_endpoint: "/server-status"
 php_fpm_socket_path: "/var/run/php/php{{ php_version }}-fpm.sock"

--- a/tasks/pagespeed.yml
+++ b/tasks/pagespeed.yml
@@ -15,6 +15,28 @@
     mode: 0644
     owner: root
     group: root
+  when: ansible_lsb.major_release|int < 16
+
+- block:
+  - name: Install create_pagespeed_cache_folder service (systemd)
+    template:
+      src: systemd/create_pagespeed_cache_folder.service.j2
+      dest: /etc/systemd/system/create_pagespeed_cache_folder.service
+      mode: 0644
+      owner: root
+      group: root
+
+  - name: Enable the create_pagespeed_cache_folder service (systemd)
+    service:
+      name: create_pagespeed_cache_folder
+      enabled: yes
+
+  - name: Start the create_pagespeed_cache_folder service (systemd)
+    service:
+      name: create_pagespeed_cache_folder
+      state: started
+    ignore_errors: true
+  when: ansible_lsb.major_release|int >= 16
 
 - name: Copy the pagespeed-upstart.sh bash script
   template:

--- a/templates/systemd/create_pagespeed_cache_folder.service.j2
+++ b/templates/systemd/create_pagespeed_cache_folder.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Unit for create_pagespeed_cache_folder
+
+[Service]
+Type=oneshot
+Environment="DATE_FORMAT=-u +%Y-%m-%dT%T.%3NZ"
+ExecStart=exec bash -c {{ scripts_dir }}/apache-pagespeed/pagespeed-upstart.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
https://beamly.atlassian.net/browse/SOP-1144

Okay ... so this is a couple of things ...

1. Default PHP to a sensible version (it's declared everywhere to php7.2 already, and if it isn't ... then it _should_ be failing, as it'll be insecure).
2. Adds a systemd version of the upstart initialisation, we're using this on coty2 and I guess it isn't creating the cache directory...