### PR TITLE
Move to using AWS metatag information for the pagespeed conf file.

### DIFF
--- a/files/pagespeed.conf.j2
+++ b/files/pagespeed.conf.j2
@@ -3,16 +3,6 @@
     # can set this to "off".
     ModPagespeed on
 
-    ModPagespeedModifyCachingHeaders off
- 
-    # We're behind an ELB - Serve traffic on whatever protocol we're being requested in
-    ModPagespeedRespectXForwardedProto on
-
-    # We want VHosts to inherit global configuration.
-    # If this is not included, they'll be independent (except for inherently
-    # global options), at least for backwards compatibility.
-    ModPagespeedInheritVHostConfig on
-
     # Direct Apache to send all HTML output to the mod_pagespeed
     # output handler.
     AddOutputFilterByType MOD_PAGESPEED_OUTPUT_FILTER text/html
@@ -23,7 +13,7 @@
 
     # The ModPagespeedFileCachePath directory must exist and be writable
     # by the apache user (as specified by the User directive).
-    ModPagespeedFileCachePath            "/tmp/pagespeed"
+    ModPagespeedFileCachePath            "/tmp/pagespeed/"
 
     # LogDir is needed to store various logs, including the statistics log
     # required for the console.
@@ -31,7 +21,6 @@
 
     # The locations of SSL Certificates is distribution-dependent.
     ModPagespeedSslCertDirectory "/etc/ssl/certs"
-
 
     # If you want, you can use one or more memcached servers as the store for
     # the mod_pagespeed cache.
@@ -58,7 +47,7 @@
     # ModPagespeedDisableFilters. This directive contains a
     # comma-separated list of filter names, and can be repeated.
     #
-    ModPagespeedDisableFilters convert_jpeg_to_webp,convert_to_webp_animated,convert_to_webp_lossless,convert_png_to_jpeg
+    # ModPagespeedDisableFilters rewrite_images
 
     # Explicitly enables specific filters. This is useful in
     # conjuction with ModPagespeedRewriteLevel. For instance, filters
@@ -88,7 +77,7 @@
     # mod_pagespeed will wait indefinitely for the rewrite to complete before
     # returning.
     #
-    ModPagespeedRewriteDeadlinePerFlushMs 500
+    # ModPagespeedRewriteDeadlinePerFlushMs 10
 
     # ModPagespeedDomain
     # authorizes rewriting of JS, CSS, and Image files found in this
@@ -141,7 +130,7 @@
     ModPagespeedFileCacheInodeLimit        500000
 
     # Bound the number of images that can be rewritten at any one time; this
-    # avoids overloading the CPU.  Set this to 0 to remove the bound.
+    # avoids overloading the CPU.  Set this to -1 to remove the bound.
     #
     # ModPagespeedImageMaxRewritesAtOnce      8
 
@@ -185,7 +174,7 @@
     # User-Agent headers as appropriate.  Note that this may require configuring
     # reverse proxy caches such as varnish to handle these headers properly.
     #
-    # ModPagespeedFilters in_place_optimize_for_browser
+    # ModPagespeedEnableFilters in_place_optimize_for_browser
 
     # Internet Explorer has difficulty caching resources with Vary: headers.
     # They will either be uncached (older IE) or require revalidation.  See:
@@ -199,11 +188,11 @@
     # Settings for image optimization:
     #
     # Lossy image recompression quality (0 to 100, -1 just strips metadata):
-    ModPagespeedImageRecompressionQuality 80
+    # ModPagespeedImageRecompressionQuality 85
     #
     # Jpeg recompression quality (0 to 100, -1 uses ImageRecompressionQuality):
-    ModPagespeedJpegRecompressionQuality -1
-    ModPagespeedJpegRecompressionQualityForSmallScreens 80
+    # ModPagespeedJpegRecompressionQuality -1
+    # ModPagespeedJpegRecompressionQualityForSmallScreens 70
     #
     # WebP recompression quality (0 to 100, -1 uses ImageRecompressionQuality):
     # ModPagespeedWebpRecompressionQuality 80
@@ -353,4 +342,29 @@
     # its default value is 100k bytes.
     # Set it to 0 if you want to disable this feature.
     ModPagespeedMessageBufferSize 100000
+
+    # Beamly configuration.
+    ModPagespeedModifyCachingHeaders off
+
+    # We're behind an ELB - Serve traffic on whatever protocol we're being requested in
+    ModPagespeedRespectXForwardedProto on
+
+    # We want VHosts to inherit global configuration.
+    # If this is not included, they'll be independent (except for inherently
+    # global options), at least for backwards compatibility.
+    ModPagespeedInheritVHostConfig on
+
+    ModPagespeedDisableFilters convert_jpeg_to_webp,convert_to_webp_animated,convert_to_webp_lossless,convert_png_to_jpeg
+
+    ModPagespeedRewriteDeadlinePerFlushMs 500
+
+    # Settings for image optimization:
+    # Lossy image recompression quality (0 to 100, -1 just strips metadata):
+    ModPagespeedImageRecompressionQuality 80
+    # Jpeg recompression quality (0 to 100, -1 uses ImageRecompressionQuality):
+    ModPagespeedJpegRecompressionQuality -1
+    ModPagespeedJpegRecompressionQualityForSmallScreens 80
+
+    ModPagespeedMapOriginDomain "http://localhost" "{{ live_domain_override | default(fastly_domain,True) }}{{ drupal_subdir }}"
+    # ModPagespeedLoadFromFile "{{ live_domain_override | default(fastly_domain,True) }}{{ drupal_subdir }}" "{{ docroot }}/"
 </IfModule>

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,2 +1,4 @@
 jinja2
+requests
+backoff
 boto3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -156,11 +156,6 @@
     group: www-data
     mode: 0700
 
-- name: Write the pagespeed module configuration
-  copy:
-    src: pagespeed.conf
-    dest: /etc/apache2/mods-available/pagespeed.conf
-
 - name: Disable the pagespeed module
   apache2_module: state=absent name=pagespeed
   when: not enable_pagespeed

--- a/tasks/pagespeed.yml
+++ b/tasks/pagespeed.yml
@@ -8,6 +8,22 @@
   debug:
     var: shared_filesystem_type
 
+- name: Copy the pagespeed.conf template
+  copy:
+    src: files/pagespeed.conf.j2
+    dest: "{{ scripts_dir }}/apache-pagespeed/pagespeed.conf.j2"
+    owner: "{{ scripts_owner }}"
+    group: "{{ scripts_group }}"
+    mode: 0755
+
+- name: Copy the webhop-write-pagespeed-conf-file script
+  template:
+    src: "write_pagespeed_conf_file.py.j2"
+    dest: "{{ scripts_dir }}/apache-pagespeed/write_pagespeed_conf_file.py"
+    owner: "{{ scripts_owner }}"
+    group: "{{ scripts_group }}"
+    mode: 0755
+
 - name: Install Upstart script
   template:
     src: upstart/create_pagespeed_cache_folder.conf.j2

--- a/templates/pagespeed-upstart.sh.j2
+++ b/templates/pagespeed-upstart.sh.j2
@@ -44,3 +44,11 @@
 
     sudo ln -sfn "${MOUNT_POINT}/pagespeed" /tmp/pagespeed
     echo "Created symlink for Pagespeed cache directory."
+
+    echo "Templating pagespeed.conf..."
+    {{ virtualenv_dir }}/apache-pagespeed/bin/python {{ scripts_dir }}/apache-pagespeed/write_pagespeed_conf_file.py \
+        --shared-filesystem-type "${FS_TYPE}" \
+        {% if drush_live_domain_override is defined %}--live-domain-override  '{{ drush_live_domain_override }}'{% endif %} \
+        {% if docroot is defined %}--docroot {{ docroot }}{% endif %} \
+        {% if drupal_subdir is defined %}--drupal-subdir {{ drupal_subdir }}{% endif %} \
+    echo "Done."

--- a/templates/write_pagespeed_conf_file.py.j2
+++ b/templates/write_pagespeed_conf_file.py.j2
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+
+'''
+Reads various settings from AWS, RDS, elasticache, and renders some configuration file templates
+'''
+
+import hashlib
+import jinja2
+import logging
+import os
+import re
+import requests
+import time
+from optparse import OptionParser
+import boto3
+import backoff
+from requests.exceptions import ConnectionError
+
+LOG = logging.getLogger(__name__)
+
+EC2_METADATA_SERVICE_ENDPOINT = "http://169.254.169.254/latest"
+
+RENDER_FILES = {'{{ scripts_dir }}/apache-pagespeed/pagespeed.conf.j2': '/etc/apache2/mods-available/pagespeed.conf'}
+
+def get_command_line_options():
+    parser = OptionParser()
+    parser.add_option("--shared-filesystem-type", action="store", dest="shared_filesystem_type", type="string", default="efs")
+    parser.add_option("--live-domain-override", action="store", dest="live_domain_override", type="string", default="")
+    parser.add_option("--docroot", action="store", dest="docroot", type="string", default="{{ drupal_docroot | default(docroot,True) }}")
+    parser.add_option("--drupal-subdir", action="store", dest="drupal_subdir", type="string", default="")
+    (options, args) = parser.parse_args()
+    return options
+
+
+def parse_tags(original_tags=[]):
+    tags = {}
+    for tag in original_tags:
+        tags[tag["Key"]] = tag["Value"]
+    return tags
+
+
+@backoff.on_exception(backoff.fibo,
+                      requests.exceptions.RequestException,
+                      max_tries=3)
+def get_instance_identity(timeout=2):
+    return requests.get('{0}/dynamic/instance-identity/document'.format(
+        EC2_METADATA_SERVICE_ENDPOINT
+    ), timeout=timeout).json()
+
+
+@backoff.on_exception(backoff.fibo,
+                      requests.exceptions.RequestException,
+                      max_tries=3)
+def get_instance_reservation_id(timeout=2):
+    return requests.get('{0}/meta-data/reservation-id'.format(
+        EC2_METADATA_SERVICE_ENDPOINT
+    ), timeout=timeout).text
+
+
+
+def get_instance_config():
+    """
+    Use the instance metadata API to get region, instance ID
+
+    """
+    LOG.info("Finding instance reservation ID and ENI ID...")
+    config = {}
+    # Find my instance ID
+    try:
+        identity_data = get_instance_identity()
+        reservation_id = get_instance_reservation_id()
+    except ConnectionError:
+        # IndexError because boto throws this
+        # when it tries to parse empty response
+        raise SystemExit(
+            "Could not connect to instance metadata endpoint, bailing...")
+
+    config["inst_id"] = identity_data["instanceId"]
+    config["region"] = identity_data["region"]
+    config["reservation_id"] = reservation_id
+
+    for k, v in config.iteritems():
+        LOG.info("Found %s with value %s", k, v)
+    return config
+
+
+def get_my_instance_object(instance_id, region, required_tags=None):
+    """
+    Queries AWS and retrieves an instance object for the given
+    instance ID.
+    """
+    LOG.info("Searching for instance object with ID: %s", instance_id)
+
+    conn = boto3.client('ec2', region_name=region)
+    response = conn.describe_instances()
+
+    instances = [i for r in response["Reservations"] for i in r["Instances"]]
+    for instance in instances:
+        if instance["InstanceId"] == instance_id:
+            LOG.info("Found instance object")
+
+            # Check it has tags before returning
+            if required_tags:
+                instance = poll_inst_tags(
+                    instance, required_tags=required_tags)
+            return instance
+
+
+def poll_inst_tags(inst, required_tags=None):
+    """
+    Polls instance object until all required tags are present
+
+    """
+    tags = parse_tags(inst["Tags"])
+    while not all(tag in tags for tag in required_tags):
+        LOG.info("Waiting 5 seconds for tags to be available...")
+        time.sleep(5)
+        inst.update()
+
+    LOG.info("Instance had tags...")
+    return inst
+
+
+def get_my_vpc(vpc_id, region="eu-central-1"):
+    conn = boto3.client('ec2', region)
+    try:
+        return conn.describe_vpcs(VpcIds=[vpc_id])["Vpcs"][0]
+    except Exception:
+         LOG.error("Found no vpc with ID: %s, bailing...", vpc_id)
+         raise SystemExit("Could not find vpc")
+
+def write_config():
+    LOG.info("Getting instance metadata...")
+    inst_config = get_instance_config()
+    region = inst_config["region"]
+
+    required_tags = ["brand", "environment"]
+
+    # Get instance object
+    inst = get_my_instance_object(
+        instance_id=inst_config["inst_id"], 
+        region=region, 
+        required_tags=required_tags
+    )
+    tags = parse_tags(inst["Tags"])
+    vpc_id = inst["VpcId"]
+
+    # get vpc object
+    my_vpc = get_my_vpc(vpc_id)
+
+    # parse tags
+    vpc_tags = {}
+    for tag in my_vpc["Tags"]:
+        vpc_tags[tag["Key"]] = tag["Value"]
+
+    LOG.info("Using domain name: %s", vpc_tags["domain_name"])
+    template_vars = {}
+    template_vars["fastly_domain"] = "https://{0}".format(vpc_tags["domain_name"])
+
+    template_vars["env"] = tags["environment"]
+    template_vars["brand"] = tags["brand"]
+
+    options = get_command_line_options()
+    template_vars["live_domain_override"] = options.live_domain_override
+    template_vars["shared_filesystem_type"] = options.shared_filesystem_type
+    template_vars["docroot"] = options.docroot
+    template_vars["drupal_subdir"] = options.drupal_subdir
+    # write the settings file from the template
+    templateLoader = jinja2.FileSystemLoader(searchpath="/")
+    templateEnv = jinja2.Environment(loader=templateLoader)
+
+    for template_source in RENDER_FILES:
+        template = templateEnv.get_template(template_source)
+        template_render_target = RENDER_FILES[template_source]
+
+        with open(template_render_target, 'w') as f:
+            os.chmod(template_render_target, 0o0644) # protect file from modifications
+            f.write(template.render(template_vars))
+
+if __name__ == "__main__":
+    FORMAT = "%(asctime)-15s : %(levelname)-8s : %(message)s"
+    logging.basicConfig(format=FORMAT, level=logging.INFO)
+    write_config()


### PR DESCRIPTION
https://www.modpagespeed.com/doc/https_support#rewrite_domains
https://www.modpagespeed.com/doc/https_support#load_from_file

Note, I initially used the "load_from_file" option but it then occurred to me that this wouldn't account for Drupals image caching functionality.  I'll maybe test it some more (to see if there is http fallback ... which seems unlikely) as this is obviously the more preferable option.

Now, I'm just rewriting the domains to be "http://localhost" then there isn't a certificate to check.